### PR TITLE
feat: add vatic package scaffold and Nix dev environment (#2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,56 @@
 .blip/
 .env
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+.venv
+venv/
+ENV/
+env/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Nix
+result
+result-*
+.dirlocals

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,53 @@
+{
+  description = "vatic — AI-driven vault editor for personal knowledge management";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        python = pkgs.python3;
+        pythonPackages = python.pkgs;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          name = "vatic-dev";
+          buildInputs = with pkgs; [
+            # Python and package management
+            python
+            pythonPackages.pip
+            pythonPackages.setuptools
+            pythonPackages.wheel
+
+            # Project dependencies
+            pythonPackages.click
+            pythonPackages.platformdirs
+            pythonPackages.tomli-w
+
+            # Optional dev dependencies
+            pythonPackages.pytest
+            pythonPackages.pytest-cov
+            pythonPackages.black
+            pythonPackages.ruff
+            pythonPackages.mypy
+
+            # External tools
+            obsidian
+          ];
+
+          shellHook = ''
+            # Install the vatic package in editable mode
+            if [ ! -d ".venv" ]; then
+              ${python}/bin/python -m venv .venv
+            fi
+            source .venv/bin/activate
+            pip install -e .
+          '';
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
         python = pkgs.python3;
         pythonPackages = python.pkgs;
       in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vatic"
+version = "0.1.0"
+description = "AI-driven vault editor for personal knowledge management"
+requires-python = ">=3.11"
+authors = [
+    {name = "Mads Kristiansen", email = "mads.kristiansen@eficode.com"},
+]
+license = {text = "MIT"}
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Utilities",
+]
+dependencies = [
+    "click>=8.0",
+    "platformdirs>=3.0",
+    "tomli-w>=1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+    "black>=23.0",
+    "ruff>=0.1",
+    "mypy>=1.0",
+]
+
+[project.scripts]
+vatic = "vatic.cli:main"
+
+[tool.setuptools]
+packages = ["vatic"]
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "UP", "W"]
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false

--- a/vatic/__init__.py
+++ b/vatic/__init__.py
@@ -1,0 +1,3 @@
+"""vatic — AI-driven vault editor for personal knowledge management."""
+
+__version__ = "0.1.0"

--- a/vatic/__main__.py
+++ b/vatic/__main__.py
@@ -1,0 +1,6 @@
+"""CLI entry point for vatic."""
+
+from vatic.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/vatic/check_review.py
+++ b/vatic/check_review.py
@@ -1,0 +1,15 @@
+"""Parse and check review status.
+
+Parses _meta/review.md and checks which entries are answered.
+"""
+
+
+def parse_review_file(content: str) -> dict:
+    """Parse review.md file."""
+    # Placeholder for review parsing logic
+    return {}
+
+
+def check_answered(review_data: dict) -> bool:
+    """Check if all review entries are answered."""
+    raise NotImplementedError

--- a/vatic/cli.py
+++ b/vatic/cli.py
@@ -1,0 +1,42 @@
+"""Command-line interface for vatic."""
+
+import click
+
+
+@click.group()
+def main():
+    """vatic — AI-driven vault editor for personal knowledge management."""
+    pass
+
+
+@main.command()
+@click.option('--dry-run', is_flag=True, help='Show what would happen without writing')
+def inbox(dry_run):
+    """Process all files in inbox/."""
+    click.echo(f"inbox command (dry_run={dry_run})")
+
+
+@main.command()
+@click.argument('question')
+@click.option('--save', is_flag=True, help='Save result as a note')
+def ask(question, save):
+    """Q&A against the vault."""
+    click.echo(f"ask: {question} (save={save})")
+
+
+@main.group()
+def config():
+    """Manage vatic configuration."""
+    pass
+
+
+@config.command("set")
+@click.argument("key")
+@click.argument("value")
+def config_set(key, value):
+    """Set a configuration value."""
+    click.echo(f"vatic config set: not yet implemented")
+
+
+if __name__ == "__main__":
+    main()

--- a/vatic/commit_staging.py
+++ b/vatic/commit_staging.py
@@ -1,0 +1,14 @@
+"""Commit staging output to vault.
+
+Validates and commits staging output after agents complete.
+"""
+
+
+def validate_staging(staging_path: str) -> bool:
+    """Validate staging directory."""
+    return True
+
+
+def commit_to_vault(staging_path: str, vault_path: str) -> None:
+    """Commit staging output to vault."""
+    pass

--- a/vatic/config.py
+++ b/vatic/config.py
@@ -1,0 +1,69 @@
+"""Configuration management for vatic.
+
+Reads/writes ~/.config/vatic/config.toml (XDG-compliant).
+"""
+
+from pathlib import Path
+import tomllib
+
+try:
+    import tomli_w as toml_write
+except ImportError:
+    toml_write = None
+
+
+def get_config_dir() -> Path:
+    """Get vatic config directory (~/.config/vatic)."""
+    try:
+        from platformdirs import user_config_dir
+        return Path(user_config_dir("vatic"))
+    except ImportError:
+        # Fallback if platformdirs not available
+        return Path.home() / ".config" / "vatic"
+
+
+def get_config_path() -> Path:
+    """Get vatic config file path."""
+    return get_config_dir() / "config.toml"
+
+
+def load_config() -> dict:
+    """Load config from ~/.config/vatic/config.toml."""
+    config_path = get_config_path()
+    if not config_path.exists():
+        return {}
+    
+    with open(config_path, 'rb') as f:
+        return tomllib.load(f)
+
+
+def save_config(config: dict) -> None:
+    """Save config to ~/.config/vatic/config.toml."""
+    if toml_write is None:
+        raise RuntimeError("tomli-w is required to write config")
+
+    config_dir = get_config_dir()
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    config_path = get_config_path()
+    with open(config_path, 'wb') as f:
+        toml_write.dump(config, f)
+
+
+def get_vault() -> Path | None:
+    """Return configured vault path, or None if not set."""
+    value = load_config().get("vault")
+    return Path(value) if value else None
+
+
+def get_tooling_repo() -> Path | None:
+    """Return configured tooling repo path, or None if not set."""
+    value = load_config().get("tooling_repo")
+    return Path(value) if value else None
+
+
+def set_value(key: str, value: str) -> None:
+    """Set a config key to value and persist."""
+    config = load_config()
+    config[key] = value
+    save_config(config)

--- a/vatic/pre_screen.py
+++ b/vatic/pre_screen.py
@@ -1,0 +1,15 @@
+"""Pre-flight screening for inbox items.
+
+Detects bare URLs and empty inbox files before spawning agents.
+"""
+
+
+def is_bare_url(content: str) -> bool:
+    """Check if content is a bare URL."""
+    content = content.strip()
+    return content.startswith('http://') or content.startswith('https://')
+
+
+def is_empty_or_unreadable(content: str) -> bool:
+    """Check if content is empty or unreadable."""
+    return not content or not content.strip()


### PR DESCRIPTION
Closes #2

## Problem

No Python package, entry point, or reproducible dev environment existed. Every subsequent issue depends on a consistent base — importable `vatic` modules, a working `vatic` CLI on `$PATH`, and a Nix shell that delivers that environment deterministically.

## Changes

- `vatic/` — new Python package with six modules:
  - `cli.py` — Click group with `inbox`, `ask`, and `config set` subcommands
  - `config.py` — XDG config via `platformdirs`; exposes `get_vault()`, `get_tooling_repo()`, `set_value()`
  - `pre_screen.py`, `check_review.py`, `commit_staging.py` — stubs for later issues
  - `__init__.py`, `__main__.py` — package wiring
- `pyproject.toml` — declares `vatic = "vatic.cli:main"` entry point, `>=3.11`, dev extras, ruff/mypy/black config
- `flake.nix` — devShell with `python3`, `obsidian`, and `pip install -e .` shellHook
- `.gitignore` — Python, venv, Nix, and IDE patterns added

## Why

Two issues found during review were fixed before committing:

- `config.py` originally returned `Path("")` when vault/tooling_repo keys were absent, which resolves to cwd and silently passes `.exists()` checks. Changed to `Optional[Path]` returning `None`.
- `check_answered` returned hardcoded `True`, which would have caused any downstream gate to always pass. Changed to `raise NotImplementedError`.

The `flake.nix` references `pkgs.obsidian` (the correct nixpkgs attribute) rather than the non-existent `obsidian-cli`. A follow-up issue (#3) tracks removing the duplicated dep list between `buildInputs` and `pyproject.toml`.

## How to verify

1. `nix develop` — shell should activate without errors; confirm `python3 --version` ≥ 3.11 and `vatic --help` is reachable
2. `vatic inbox` — prints stub message
3. `vatic config set vault /tmp/test` — recognised command, prints stub message
4. `python -c "from vatic.config import get_vault; print(get_vault())"` — prints `None` (unconfigured)
5. `python -c "from vatic.cli import main"` — no import error
